### PR TITLE
move args processing code into led_cube.py / rb change dll load path to absolute from relative in order to debug visual code.

### DIFF
--- a/content/python2/lib/led_cube.py
+++ b/content/python2/lib/led_cube.py
@@ -1,14 +1,24 @@
 import os
 from ctypes import *
 from sys import platform
+import sys
 
+dirname = os.path.dirname(__file__)
 if platform == 'darwin':
-    ledlib = './lib/libledLib.dylib'
+    ledlib = dirname + '/libledLib.dylib'
 elif platform == 'win32':
-    ledlib = './lib/ledLib32.dll'
+    ledlib = dirname + '/ledLib32.dll'
 elif platform == 'win64':
-    ledlib = './lib/ledLib64.dll'
+    ledlib = dirname + '/ledLib64.dll'
 else:
     raise NotImplementedError('Unsupported OS.')
 
 led = cdll.LoadLibrary(ledlib)
+
+argvs = sys.argv
+argc = len(argvs)
+
+if argc > 1:
+    led.SetUrl(argvs[1])
+ 
+ 

--- a/content/python3/lib/led_cube.py
+++ b/content/python3/lib/led_cube.py
@@ -1,15 +1,24 @@
 import os
 from ctypes import *
 from sys import platform
+import sys
 
-cd = os.path.dirname(__file__)
+dirname = os.path.dirname(__file__)
 if platform == 'darwin':
-    ledlib = cd + '/libledLib.dylib'
+    ledlib = dirname + '/libledLib.dylib'
 elif platform == 'win32':
-    ledlib = cd + '/ledLib32.dll'
+    ledlib = dirname + '/ledLib32.dll'
 elif platform == 'win64':
-    ledlib = cd + '/ledLib64.dll'
+    ledlib = dirname + '/ledLib64.dll'
 else:
     raise NotImplementedError('Unsupported OS.')
 
 led = cdll.LoadLibrary(ledlib)
+
+argvs = sys.argv
+argc = len(argvs)
+
+if argc > 1:
+    led.SetUrl(argvs[1])
+ 
+ 

--- a/content/ruby/helloworld.rb
+++ b/content/ruby/helloworld.rb
@@ -4,8 +4,6 @@ WIDTH = 16
 HEIGHT = 32
 DEPTH = 8
 
-LED.SetUrl(ARGV[0]) if 0 < ARGV.size
-
 loop do
   LED.ShowMotioningText1("HELLOWORLD!")
 end

--- a/content/ruby/lib/led_cube.rb
+++ b/content/ruby/lib/led_cube.rb
@@ -22,14 +22,15 @@ end
 module LED
   extend Fiddle::Importer
 
+  dirname = File.dirname(__FILE__)
   case os
   when :macosx
-    dlload './lib/libledLib.dylib'
+    dlload dirname + '/libledLib.dylib'
   when :windows
     if RbConfig::CONFIG['target_cpu'] == 'i386' then
-      dlload './lib/ledLib32.dll'
+      dlload dirname + '/ledLib32.dll'
     else
-      dlload './lib/ledLib64.dll'
+      dlload dirname + '/ledLib64.dll'
     end
   else
     raise RuntimeError
@@ -42,3 +43,5 @@ module LED
   extern 'void Wait(int)'
   extern 'void ShowMotioningText1(char *)'
 end
+
+LED.SetUrl(ARGV[0]) if 0 < ARGV.size

--- a/content/ruby/run_corner.rb
+++ b/content/ruby/run_corner.rb
@@ -4,8 +4,6 @@ WIDTH = 16
 HEIGHT = 32
 DEPTH = 8
 
-LED.SetUrl(ARGV[0]) unless ARGV.empty?
-
 def corner?(pos)
   pos.zip([WIDTH, HEIGHT, DEPTH]).all? { |a, b| a.zero? || a == b - 1 }
 end

--- a/content/ruby/wave.rb
+++ b/content/ruby/wave.rb
@@ -4,8 +4,6 @@ WIDTH = 16
 HEIGHT = 32
 DEPTH = 8
 
-LED.SetUrl(ARGV[0]) if 0 < ARGV.size
-
 def can_show(x, y, z)
   (0...WIDTH).include?(x) && (0...HEIGHT).include?(y) && (0...DEPTH).include?(z)
 end


### PR DESCRIPTION
args processing code for connecting real led cube is no longer need in content side code. it move into lib side.
and small changes included.
